### PR TITLE
Add MQTT username/password support

### DIFF
--- a/src/com/angryelectron/xbmq/Main.java
+++ b/src/com/angryelectron/xbmq/Main.java
@@ -10,6 +10,7 @@ import com.angryelectron.xbmq.listener.XbmqMqttCallback;
 import com.digi.xbee.api.XBeeDevice;
 import com.digi.xbee.api.exceptions.XBeeException;
 import java.io.File;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -65,6 +66,10 @@ public class Main {
                 : config.getRootTopic();
         String broker = (cmd.hasOption("u")) ? cmd.getOptionValue("u")
                 : config.getBroker();
+        Optional<String> username = (cmd.hasOption("n")) ? Optional.of(cmd.getOptionValue("n"))
+                : config.getUsername();
+        Optional<String> password = (cmd.hasOption("p")) ? Optional.of(cmd.getOptionValue("p"))
+                : config.getPassword();
 
         /**
          * Ensure RXTX knows about non-standard serial ports. For details see
@@ -81,8 +86,8 @@ public class Main {
 
         XBeeDevice xbee = new XBeeDevice(port, Integer.parseInt(baud));
         xbee.open();
-        MqttAsyncClient mqtt = new MqttAsyncClient(broker, xbee.get64BitAddress().toString());        
-        final Xbmq xbmq = new Xbmq(xbee, mqtt, rootTopic);
+        MqttAsyncClient mqtt = new MqttAsyncClient(broker, xbee.get64BitAddress().toString());
+        final Xbmq xbmq = new Xbmq(xbee, mqtt, rootTopic, username, password);
         
         /**
          * From MqttClient Javadocs:  It is recommended to call 
@@ -164,6 +169,12 @@ public class Main {
         Option broker = OptionBuilder.withArgName("broker").hasArg()
                 .withDescription("Mqtt broker").create("u");
         options.addOption(broker);
+        Option username = OptionBuilder.withArgName("username").hasArg()
+                .withDescription("Mqtt username").create("n");
+        options.addOption(username);
+        Option password = OptionBuilder.withArgName("password").hasArg()
+                .withDescription("Mqtt password").create("p");
+        options.addOption(password);
         return options;
     }
 

--- a/src/com/angryelectron/xbmq/XbmqConfig.java
+++ b/src/com/angryelectron/xbmq/XbmqConfig.java
@@ -6,6 +6,7 @@ package com.angryelectron.xbmq;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -24,11 +25,15 @@ public class XbmqConfig {
     final String BAUD = "baud";
     final String TOPIC = "rootTopic";
     final String BROKER = "broker";
+    final String USERNAME = "username";
+    final String PASSWORD = "password";
 
     final String PORT_DEFAULT = "/dev/ttyUSB0";
     final String BAUD_DEFAULT = "9600";
     final String TOPIC_DEFAULT = "";
     final String BROKER_DEFAULT = "tcp://test.mosquitto.org:1883";
+    final Optional<String> USERNAME_DEFAULT = Optional.empty();
+    final Optional<String> PASSWORD_DEFAULT = Optional.empty();
 
     /**
      * Constructor. Loads properties from xbmq.properties.
@@ -101,5 +106,27 @@ public class XbmqConfig {
     public String getBroker() {
         String broker = properties.getProperty(BROKER, BROKER_DEFAULT);
         return broker.trim();
+    }
+
+    /**
+     * Get the username to connect to the MQTT broker.
+     *
+     * @return Username or Optional.empty() if not present.
+     */
+    public Optional<String> getUsername() {
+        Optional<String> username = Optional.ofNullable(properties.getProperty(USERNAME))
+                .map(v -> v.trim());
+        return username;
+    }
+
+    /**
+     * Get the password to connect to the MQTT broker.
+     *
+     * @return Password or Optional.empty() if not present.
+     */
+    public Optional<String> getPassword() {
+        Optional<String> password = Optional.ofNullable(properties.getProperty(PASSWORD))
+                .map(v -> v.trim());
+        return password;
     }
 }

--- a/test/com/angryelectron/xbmq/XbmqTest.java
+++ b/test/com/angryelectron/xbmq/XbmqTest.java
@@ -7,6 +7,7 @@ package com.angryelectron.xbmq;
 
 import com.digi.xbee.api.XBeeDevice;
 import com.digi.xbee.api.models.XBee64BitAddress;
+import java.util.Optional;
 import org.eclipse.paho.client.mqttv3.IMqttToken;
 import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
@@ -48,31 +49,31 @@ public class XbmqTest {
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorRequiresValidMqtt() throws Exception {        
         mqtt = null;
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);        
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());        
     }            
     
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorRequiresValidXBee() throws Exception {
         xbee = null;
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorRequiresOpenXBee() throws Exception {
         when(xbee.isOpen()).thenReturn(false);
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorRequiresClientId() {
         when(mqtt.getClientId()).thenReturn(null);
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
     }
     
     @Test(expected = IllegalArgumentException.class)
     public void testConstructorClientIdNotEmpty() {
         when(mqtt.getClientId()).thenReturn("");
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
     }
             
     @Test
@@ -81,7 +82,7 @@ public class XbmqTest {
         when(mqtt.connect((MqttConnectOptions) anyObject())).thenReturn(token);
         doNothing().when(token).waitForCompletion();        
         
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
         xbmq.connectMqtt();
         verify(mqtt).connect((MqttConnectOptions) anyObject());        
     }
@@ -99,7 +100,7 @@ public class XbmqTest {
         when(mqtt.disconnect()).thenReturn(token);
         doNothing().when(token).waitForCompletion();   
         
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
         xbmq.connectMqtt();
         xbmq.disconnect();
     }
@@ -110,7 +111,7 @@ public class XbmqTest {
         when(mqtt.disconnect()).thenReturn(token);
         doNothing().when(token).waitForCompletion();   
         
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);        
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());        
         when(xbee.isOpen()).thenReturn(false);
         when(mqtt.isConnected()).thenReturn(false);
         xbmq.disconnect();
@@ -123,7 +124,7 @@ public class XbmqTest {
         when(mqtt.connect((MqttConnectOptions) anyObject())).thenReturn(token);
         doNothing().when(token).waitForCompletion();   
         
-        Xbmq xbmq = new Xbmq(xbee, mqtt, null);
+        Xbmq xbmq = new Xbmq(xbee, mqtt, null, Optional.empty(), Optional.empty());
         xbmq.disconnect();                
     }             
         


### PR DESCRIPTION
Added the ability to optionally pass username/password for the MQTT broker from the command line and from the config file.